### PR TITLE
AI policy

### DIFF
--- a/.github/.github/AI_POLICY.md
+++ b/.github/.github/AI_POLICY.md
@@ -1,0 +1,31 @@
+We support using AI (i.e., LLMs) as tools for coding. However, you remain
+responsible for any code you publish and we are responsible for any code we
+merge and release. We hold a high bar for all contributions to our projects.
+
+**AI should not be used to generate comments when communicating with
+maintainers**. We expect comments on our projects to be written by humans. We
+may hide any comments that we believe are AI generated.
+
+If you are opening an issue, we expect you to describe the problem in your own
+words.
+
+If you are opening a pull request, we expect you to be able to explain the
+proposed changes in your own words. This includes the pull request body and
+responses to questions. **Do not copy responses from the AI when replying to
+questions from maintainers.**
+
+Due to the foundational nature of our projects, we require a human in the loop
+who understands the work produced by AI. **We do not allow autonomous agents to
+be used for contributing to our projects**. We will close any pull requests that
+we believe were created autonomously.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of the
+context. Do not share long snippets.
+
+We understand that AI is useful when communicating as a non-native English
+speaker. If you are using AI to edit your comments for this purpose, please take
+the time to ensure it reflects your own voice and ideas. If using AI for
+translation, we recommend writing in your native language and including the AI
+translation in a quote block.

--- a/.github/.github/pull_request_template.md
+++ b/.github/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# I have made things!
+<!--
+Hi, thanks for submitting a Pull Request. We appreciate it. Please, fill in all the required information to make our review and merging processes easier.
+-->
+
+## Related issues
+<!--
+Mark what issues this Pull Request closes or references.
+
+Example. Fixes #0
+Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/
+-->
+
+## AI Policy
+- [ ] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result


### PR DESCRIPTION
# I have made things!

Adds AI Policy from django-stubs repo as well as their PR template.

Close #46

Inspired by:
- https://github.com/typeddjango/django-stubs/blob/master/.github/pull_request_template.md
- https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md

## AI Policy
- [x] I have read and agree to the [AI Policy](https://github.com/typeddjango/django-stubs/blob/master/.github/AI_POLICY.md), removed any "Co-Authored-By" lines attributing coding agents, and manually reviewed the final result